### PR TITLE
[Agilio-vRouter] Add support for agilio-vrouter installation

### DIFF
--- a/contrail-agent/config.yaml
+++ b/contrail-agent/config.yaml
@@ -73,3 +73,12 @@ options:
     description: |
       Log level for contrail services. Valid values are:
       SYS_EMERG, SYS_ALERT, SYS_CRIT, SYS_ERR, SYS_WARN, SYS_NOTICE, SYS_INFO, SYS_DEBUG
+  agilio-vrouter:
+    type: boolean
+    default: false
+    description: Enable vrouter hardware acceleration with agilio SmartNics 
+  virtioforwarder-coremask:
+    type: string
+    default: "1,2"
+    description: |
+      CPU affinity mask for virtio-forwarder, comma seperated range or hex bitmask

--- a/contrail-agent/hooks/contrail_agent_hooks.py
+++ b/contrail-agent/hooks/contrail_agent_hooks.py
@@ -38,7 +38,7 @@ from charmhelpers.core.hugepage import hugepage_support
 from subprocess import (
     CalledProcessError,
     check_output,
-    call,
+    check_call,
 )
 from contrail_agent_utils import (
     configure_crashes,
@@ -83,7 +83,6 @@ def install():
         packages.extend(PACKAGES_DKMS_INIT)
         if config.get("agilio-vrouter"):
             output = check_output(["cat", "/proc/cmdline"]).rstrip()
-            print output
             if not "intel_iommu=on" in output or not "iommu=pt" in output:
                 log("intel_iommu=on missing in cmdline", ERROR)
                 status_set("blocked", "Missing iommu in cmdline")
@@ -143,10 +142,10 @@ def install_agilio():
     service("enable","virtio-forwarder")
     configure_apparmor()
     iface = config.get("physical-interface")
-    call("ifdown " + iface, shell=True)
+    check_call("ifdown " + iface, shell=True)
     configure_initramfs()
-    call("ifup " + iface, shell=True)
-    call("ifup vhost0", shell=True)
+    check_call("ifup " + iface, shell=True)
+    check_call("ifup vhost0", shell=True)
 
 def install_dkms():
     try:

--- a/contrail-agent/hooks/contrail_agent_utils.py
+++ b/contrail-agent/hooks/contrail_agent_utils.py
@@ -4,7 +4,6 @@ from socket import gethostname
 from subprocess import (
     check_call,
     check_output,
-    call,
 )
 from time import sleep, time
 import yaml
@@ -167,11 +166,11 @@ def configure_virtioforwarder():
     render("virtioforwarder", "/etc/default/virtioforwarder", ctx)
 
 def configure_initramfs():
-    call("/opt/netronome/bin/ns-vrouter-ctl start", shell=True)
-    call("update-initramfs -u", shell=True)
+    check_call("/opt/netronome/bin/ns-vrouter-ctl start", shell=True)
+    check_call("update-initramfs -u", shell=True)
 
 def configure_apparmor():
-    call('grep -qF "/{var/,}run/vrouter/** rwmix," ' \
+    check_call('grep -qF "/{var/,}run/vrouter/** rwmix," ' \
         '/etc/apparmor.d/abstractions/libvirt-qemu || ' \
         'echo "/{var/,}run/vrouter/** rwmix," >> ' \
         '/etc/apparmor.d/abstractions/libvirt-qemu',

--- a/contrail-agent/templates/contrail-vrouter-agent.conf
+++ b/contrail-agent/templates/contrail-vrouter-agent.conf
@@ -18,6 +18,9 @@ collectors = {{ analytics_nodes|join(":8086 ")~ ':8086' }}
 {%- endif %}
 log_level = {{ log_level }}
 
+{%- if agilio_vrouter %}
+offload=enabled
+{%- endif %}
 # Enable/Disable SSL based XMPP Authentication
 xmpp_auth_enable = {{ ssl_enabled }}
 xmpp_dns_auth_enable = {{ ssl_enabled }}

--- a/contrail-agent/templates/virtioforwarder
+++ b/contrail-agent/templates/virtioforwarder
@@ -1,0 +1,128 @@
+# Virtio-forwarder daemon: forward packets between SR-IOV VFs (serviced by DPDK)
+# and VirtIO network backend.
+
+#-------------------------------------------------------------------------------
+# Generally useful settings
+#-------------------------------------------------------------------------------
+
+# CPUs to use for worker threads (either comma separated integers or hex bitmap
+# starting with 0x)
+VIRTIOFWD_CPU_MASK= {{ virtioforwarder_coremask }}
+
+# Log threshold 0-7 (least to most verbose)
+VIRTIOFWD_LOG_LEVEL=6
+
+# Use IPC to add/remove VF&virtio instead of OVSDB (default: use OVSDB)
+# Set to anything non-null to enable
+VIRTIOFWD_IPC_PORT_CONTROL=y
+
+# OVSDB unix domain socket file used for port control.
+# Blank defaults to /usr/local/var/run/openvswitch/db.sock
+# Cannot use with VIRTIOFWD_IPC_PORT_CONTROL
+VIRTIOFWD_OVSDB_SOCK_PATH=
+
+# Set to anything non-null to enable
+VIRTIOFWD_JUMBO=y
+VIRTIOFWD_MRGBUF=y
+VIRTIOFWD_TSO=
+
+# vhost-user unix socket ownership username (leave blank to inherit process
+# username)
+VIRTIOFWD_SOCKET_OWNER=libvirt-qemu
+
+# vhost-user unix socket ownership groupname (leave blank to inherit process
+# groupname)
+VIRTIOFWD_SOCKET_GROUP=kvm
+
+# Mount path to hugepages for vhost-user communication with VMs
+# IMPORTANT: This must match the path configured for libvirt/QEMU!
+VIRTIOFWD_HUGETLBFS_MOUNT_POINT=/dev/hugepages
+
+# Add static VFs, in the form <PCI>=<virtio_id>, e.g. 0000:05:08.1=1
+# Multiple instances can be specified using bash array format. The following
+# are all valid:
+# VIRTIOFWD_STATIC_VFS=(0000:05:08.1=1 0000:05:08.2=2 0000:05:08.3=3)
+# VIRTIOFWD_STATIC_VFS=(0000:05:08.1=1)
+# VIRTIOFWD_STATIC_VFS=0000:05:08.1=1
+VIRTIOFWD_STATIC_VFS=
+
+# virtio-forwarder will not create or listen to any sockets when dynamic sockets
+# are enabled. Instead, socket registration/deregistration must be done through
+# the port control client. Dynamic sockets are geared towards Openstack port
+# plugging infrastructure.
+# Set to anything non-null to enable
+VIRTIOFWD_DYNAMIC_SOCKETS=y
+#-------------------------------------------------------------------------------
+
+
+#-------------------------------------------------------------------------------
+# Core scheduler settings
+# Leave blank to retain defaults
+#-------------------------------------------------------------------------------
+
+# Use dynamic load balancing. Anything else than 'true' equates to disabled
+VIO4WD_CORE_SCHED_ENABLE=false
+
+# Switching sensitivity. Higher value decrease the sensitivity
+VIO4WD_CORE_SCHED_SENSITIVITY=
+
+# Log threshold as above
+VIO4WD_CORE_SCHED_LOG_LEVEL=6
+
+# Polling interval
+VIO4WD_CORE_SCHED_POLL_INTERVAL=
+#-------------------------------------------------------------------------------
+
+
+#-------------------------------------------------------------------------------
+# Specialized settings (you probably don't need to touch these)
+#-------------------------------------------------------------------------------
+
+# VF relay to CPU pinnings
+# Notation:
+# 1. Specify exactly which CPU(s) to use for the specified VFs using the
+#    format <vf:cpu[,cpu]>. Multiple instances can be specified using bash arrays.
+#    The following are all valid:
+# VIRTIOFWD_CPU_PINS=(0:1,1 1:1,2 2:2,1)
+# VIRTIOFWD_CPU_PINS=(0:1,1)
+# VIRTIOFWD_CPU_PINS=0:1,1
+#
+# 2. A blank string, meaning to use the automatic CPU scheduling policy (no
+#    pins).
+#
+# NOTE: The core scheduler will override any of the above pinnings if it is running!
+VIRTIOFWD_CPU_PINS=
+
+# PID file (virtioforwarder.pid) will be written to this directory
+VIRTIOFWD_PID_DIR=/var/run
+
+# ZeroMQ IPC endpoint used for configuration queries
+VIRTIOFWD_ZMQ_CONFIG_EP=
+
+# ZeroMQ IPC endpoint used to add/remove SR-IOV VFs to the relay
+VIRTIOFWD_ZMQ_PORT_CONTROL_EP=ipc:///var/run/virtio-forwarder/port_control
+
+# ZeroMQ IPC endpoint used to query relay stats
+VIRTIOFWD_ZMQ_STATS_EP=ipc:///var/run/virtio-forwarder/stats
+
+# ZeroMQ IPC endpoint used for dynamic core scheduling (load balancing)
+VIRTIOFWD_ZMQ_CORE_SCHED_EP=ipc:///var/run/virtio-forwarder/core_sched
+
+# Directory containing vhost-user unix sockets
+VIRTIOFWD_SOCKET_DIR=/var/run/vrouter
+
+# vhost-user unix socket file name pattern, must contain exactly one %u to
+# denote VirtIO ID
+VIRTIOFWD_SOCKET_FNAME_PATTERN=
+
+# Path to virtio-forwarder binary (debugging knob).
+VIRTIOFWD_BINARY=/usr/bin/virtio-forwarder
+
+# CPU to use as the master lcore. Blank defaults to CPU0
+VIRTIOFWD_MASTER_LCORE=
+
+# Non-blank enables vhostuser client mode (default: server mode)
+VIRTIOFWD_VHOST_CLIENT=y
+
+# Use experimental zero-copy support (VM to NIC) (default: disabled)
+VIRTIOFWD_ZERO_COPY=


### PR DESCRIPTION
This commit adds agilio-vrouter support to the contrail-agent
charm. A config option is added to enable the installation of
agilio-vrouter.

Signed-off-by: Pieter Malan <pieter.malan@netronome.com>