### PR TITLE
Find the vhost-gateway when using the auto param

### DIFF
--- a/contrail-agent/hooks/contrail_agent_utils.py
+++ b/contrail-agent/hooks/contrail_agent_utils.py
@@ -88,9 +88,10 @@ def _get_default_gateway_iface():
 
 
 def _get_iface_gateway_ip(iface):
+    ifaces = [iface, "vhost0"]
     for line in check_output(["route", "-n"]).splitlines()[2:]:
         l = line.split()
-        if "G" in l[3] and l[7] == iface:
+        if "G" in l[3] and l[7] in ifaces:
             log("Found gateway {} for interface {}".format(l[1], iface))
             return l[1]
     log("vrouter-gateway set to 'auto' but gateway could not be determined "


### PR DESCRIPTION
* When using the auto value for the `vhost-gateway` config option, the
output of `route -n` is used to find the gateway with the initial name
of the interface that will be used for `vhost0`.
* When `vhost0` is created, the name of the inital interface is not
present in the routing table anymore. Therefore, it is necessary to also
look for `vhost0` in the routing table to have a consistent behaviour.

Fixes #56 