### PR TITLE
use json.loads for debug

### DIFF
--- a/contrail-controller/hooks/contrail_controller_hooks.py
+++ b/contrail-controller/hooks/contrail_controller_hooks.py
@@ -96,7 +96,7 @@ def leader_elected():
         leader_set(rabbitmq_password_int=password)
         update_northbound_relations()
 
-    ip_list = leader_get("controller_ip_list")
+    ip_list = json.loads(leader_get("controller_ip_list"),list())
     ips = get_controller_ips()
     if not ip_list:
         ip_list = ips.values()

--- a/contrail-controller/hooks/contrail_controller_hooks.py
+++ b/contrail-controller/hooks/contrail_controller_hooks.py
@@ -96,7 +96,7 @@ def leader_elected():
         leader_set(rabbitmq_password_int=password)
         update_northbound_relations()
 
-    ip_list = json.loads(leader_get("controller_ip_list"),list())
+    ip_list = json_loads(leader_get("controller_ip_list"),list())
     ips = get_controller_ips()
     if not ip_list:
         ip_list = ips.values()


### PR DESCRIPTION
`leader_get` returns a stringified list. So the set operations fail, and the log currently looks like:

```
unit-contrail-controller-0: 08:02:16 ERROR unit.contrail-controller/0.juju-log there are a dead controllers that are in the list: set([u'"', u'.', u'1', u'0', u'3', u'5', u'9', u'8', u'[', u']'])
```

This patch fixes that.

On a related note, why does `leader_elected` use `ips = get_controller_ips()`, when all 3 other functions which set `ips` use `ips = json_loads(leader_get("controller_ips"), dict())`? Is that a possible bug?