### PR TITLE
Get hostname and add it to ctx

### DIFF
--- a/contrail-agent/hooks/contrail_agent_utils.py
+++ b/contrail-agent/hooks/contrail_agent_utils.py
@@ -1,5 +1,5 @@
 import os
-
+import socket
 from subprocess import (
     check_call,
     check_output,
@@ -80,7 +80,7 @@ def _get_hugepages():
 
 
 def _get_default_gateway_iface():
-    #TODO: get iface from route to CONTROL_NODES
+    # TODO: get iface from route to CONTROL_NODES
     if hasattr(netifaces, "gateways"):
         return netifaces.gateways()["default"][netifaces.AF_INET][1]
 
@@ -140,6 +140,7 @@ def get_context():
         my_ip = unit_get("private-address")
         if my_ip in plugin_ips:
             ctx["plugin_settings"] = plugin_ips[my_ip]
+    ctx["hostname"] = socket.getfqdn()
 
     log("CTX: " + str(ctx))
 

--- a/contrail-agent/templates/vrouter.env
+++ b/contrail-agent/templates/vrouter.env
@@ -47,6 +47,7 @@ DPDK_COMMAND_ADDITIONAL_ARGS={{ dpdk_additional_args }}
 PHYSICAL_INTERFACE={{ physical_interface }}
 VROUTER_GATEWAY={{ vrouter_gateway }}
 VROUTER_ENCRYPTION=FALSE
+VROUTER_HOSTNAME={{ hostname }}
 
 SRIOV_PHYSICAL_INTERFACE={{ sriov_physical_interface }}
 SRIOV_VF={{ sriov_numvfs }}


### PR DESCRIPTION
Fixes an issue where the vrouter agent registers itself with the wrong name because the reverse DNS resolution with MAAS might give some unexpected results (e.g. <interface>.<vlan>.hostname.domain)