### PR TITLE
vrouter hostname should reflect MAAS vhost0 interface name

### DIFF
--- a/contrail-agent/hooks/contrail_agent_utils.py
+++ b/contrail-agent/hooks/contrail_agent_utils.py
@@ -142,7 +142,9 @@ def get_context():
         my_ip = unit_get("private-address")
         if my_ip in plugin_ips:
             ctx["plugin_settings"] = plugin_ips[my_ip]
-    ctx["hostname"] = socket.getfqdn()
+    ctx["hostname"] = socket.getfqdn(get_vhost_ip())
+    if ctx["hostname"] == get_vhost_ip():
+        ctx["hostname"] = socket.getfqdn()
 
     log("CTX: " + str(ctx))
 


### PR DESCRIPTION
with MAAS every interface has it's own DNS name, like bond0.hostname.fqdn, bond1.300.hostname.fqdn. Without this patch vrouters are provisioned with hostname.fqdn, but registering themselves as <vhost_physical_interface_name[.optional_vlan].hostname.fqdn

in case of non-maas environment I've also added a case when vhost ip will not be resolved to a name. in that case primary name will be used.